### PR TITLE
Add notification for ActiveSupport::Messages::Rotator#run_rotations

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -567,7 +567,10 @@ module ActionDispatch
 
         def deserialize(name)
           rotate = false
-          value  = yield -> { rotate = true }
+          value  = yield -> (notification_payload) {
+            notification_payload[:cookie_name] = name
+            rotate = true
+          }
 
           if value
             case

--- a/actionpack/test/dispatch/cookies_test.rb
+++ b/actionpack/test/dispatch/cookies_test.rb
@@ -577,6 +577,28 @@ class CookiesTest < ActionController::TestCase
     assert_equal 45, verifier.verify(@response.cookies["user_id"])
   end
 
+  def test_notification_for_rotation
+    events = []
+
+    ActiveSupport::Notifications.subscribe "rotation.active_support" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    secret = "b3c631c314c0bbca50c1b2843150fe33"
+
+    @request.env["action_dispatch.signed_cookie_digest"] = "SHA256"
+    @request.env["action_dispatch.cookies_rotations"].rotate :signed, secret, digest: "SHA1"
+
+    old_message = ActiveSupport::MessageVerifier.new(secret, digest: "SHA1", serializer: Marshal).generate(45)
+    @request.headers["Cookie"] = "user_id=#{old_message}"
+
+    get :get_signed_cookie
+
+    assert_equal :user_id, events[0].payload[:cookie_name]
+  ensure
+    ActiveSupport::Notifications.unsubscribe("rotation.active_support")
+  end
+
   def test_tampered_with_signed_cookie
     key_generator = @request.env["action_dispatch.key_generator"]
     secret = key_generator.generate_key(@request.env["action_dispatch.signed_cookie_salt"])

--- a/activesupport/lib/active_support/messages/rotator.rb
+++ b/activesupport/lib/active_support/messages/rotator.rb
@@ -47,7 +47,10 @@ module ActiveSupport
         def run_rotations(on_rotation)
           @rotations.find do |rotation|
             if message = yield(rotation) rescue next
-              on_rotation&.call
+              ActiveSupport::Notifications.instrument("rotation.active_support") do |payload|
+                on_rotation&.call(payload)
+              end
+
               return message
             end
           end

--- a/activesupport/test/secure_compare_rotator_test.rb
+++ b/activesupport/test/secure_compare_rotator_test.rb
@@ -38,14 +38,14 @@ class SecureCompareRotatorTest < ActiveSupport::TestCase
     @witness = nil
 
     assert_changes(:@witness, from: nil, to: true) do
-      assert_equal(true, wrapper.secure_compare!("and_another_one", on_rotation: -> { @witness = true }))
+      assert_equal(true, wrapper.secure_compare!("and_another_one", on_rotation: -> (_) { @witness = true }))
     end
   end
 
   test "#secure_compare! calls the on_rotation proc that given in constructor" do
     @witness = nil
 
-    wrapper = ActiveSupport::SecureCompareRotator.new("old_secret", on_rotation: -> { @witness = true })
+    wrapper = ActiveSupport::SecureCompareRotator.new("old_secret", on_rotation: -> (_) { @witness = true })
     wrapper.rotate("new_secret")
     wrapper.rotate("another_secret")
     wrapper.rotate("and_another_one")

--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -522,6 +522,18 @@ INFO. Cache stores may add their own keys
 }
 ```
 
+### rotation.active_support
+
+| Key            | Value                                             |
+| -------------- | ------------------------------------------------- |
+| `:cookie_name` | Name of the cookie on which the rotation occurred |
+
+```ruby
+{
+  cookie_name: "user_id",
+}
+```
+
 Active Job
 ----------
 


### PR DESCRIPTION
Adds the ability to easily monitor rotations. With the ability to know which cookies are impacted.
The goal is to know when the rotation can be safely removed.

This is an extraction of what we use at Doctolib, when we rotate some secrets.