### PR TITLE
Add multi database support for pending migration error

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,7 @@
+*   Add `PendingMigrationError` actionable error multi database support
+
+    *Florent Beaurain*
+
 *   Add `ActiveRecord::Relation#readonly?`.
 
     Reflects if the relation has been marked as readonly.

--- a/activerecord/lib/active_record/migration.rb
+++ b/activerecord/lib/active_record/migration.rb
@@ -151,12 +151,8 @@ module ActiveRecord
     include ActiveSupport::ActionableError
 
     action "Run pending migrations" do
-      ActiveRecord::Tasks::DatabaseTasks.migrate
-
-      if ActiveRecord.dump_schema_after_migration
-        connection = ActiveRecord::Tasks::DatabaseTasks.migration_connection
-        ActiveRecord::Tasks::DatabaseTasks.dump_schema(connection.pool.db_config)
-      end
+      Rails.application.load_tasks
+      Rake::Task["db:migrate"].invoke
     end
 
     def initialize(message = nil, pending_migrations: nil)


### PR DESCRIPTION
### Motivation / Background

`PendingMigrationError` actionable error currently does not support a multi database setup. The goal of this PR is to add support for multi database setup.

### Detail

I have chosen to directly invoke the `db:migrate` rake task in the action, so any code change to the migrate task will be reflected. But I'm really unsure about this implementation, as it require to `Rails.application.load_tasks` and I can't find any similar pattern anywhere in the codebase.

### Checklist

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
